### PR TITLE
Fix: work in SuppliersController, SupliersService

### DIFF
--- a/Lekarna.Common/GlobalConstants.cs
+++ b/Lekarna.Common/GlobalConstants.cs
@@ -28,6 +28,10 @@
         {
             public const string Key = "Notification";
 
+            public const string Error = "Error";
+
+            public const string SuplierAlreadyExists = "Supplier with that name alredy exists!";
+
             public const string SuccessfullyCreatedPharmacy = "Pharmacy was successfully created!";
 
             public const string SuccessfullyEditedPharmacy = "Pharmacy was successfully edited!";
@@ -39,13 +43,12 @@
             public const string SuccessfullyDeletedCategory = "Category was successfully deleted!";
 
             public const string SuccessfullyEditedCategory = "Category was successfully edited!";
-          
+
             public const string SuccessfullyCreatedSupplier = "Supplier was successfully created!";
 
             public const string SuccessfullyEditedSupplier = "Supplier was successfully edited!";
 
             public const string SuccessfullyDeletedSupplier = "Supplier was successfully deleted!";
-
         }
 
         public static class Offer

--- a/Services/Lekarna.Services.Data/Categories/CategoriesService.cs
+++ b/Services/Lekarna.Services.Data/Categories/CategoriesService.cs
@@ -7,7 +7,6 @@
     using Lekarna.Data.Common.Repositories;
     using Lekarna.Data.Models;
     using Lekarna.Services.Mapping;
-    using Lekarna.Web.ViewModels.Categories;
     using Microsoft.EntityFrameworkCore;
 
     public class CategoriesService : ICategoriesService

--- a/Services/Lekarna.Services.Data/Suppliers/ISuppliersService.cs
+++ b/Services/Lekarna.Services.Data/Suppliers/ISuppliersService.cs
@@ -15,9 +15,9 @@
 
         Task<string> DeleteAsync(string id);
 
-        T GetByName<T>(string name);
+        Task<T> GetByName<T>(string name);
 
-        T GetById<T>(string id);
+        Task<T> GetById<T>(string id);
 
         Task<IEnumerable<T>> GetAllSuppliers<T>(int? take = null, int skip = 0);
 

--- a/Services/Lekarna.Services.Data/Suppliers/SuppliersService.cs
+++ b/Services/Lekarna.Services.Data/Suppliers/SuppliersService.cs
@@ -7,7 +7,6 @@
     using Lekarna.Data.Common.Repositories;
     using Lekarna.Data.Models;
     using Lekarna.Services.Mapping;
-    using Lekarna.Web.ViewModels.Suppliers;
     using Microsoft.AspNetCore.Http;
     using Microsoft.EntityFrameworkCore;
 
@@ -33,7 +32,10 @@
                 Address = address,
             };
 
-            var dbSupplier = this.suppliersRepository.All().Where(s => s.Name == supplier.Name).FirstOrDefault();
+            var dbSupplier = await this.suppliersRepository
+                .All()
+                .Where(s => s.Name == supplier.Name)
+                .FirstOrDefaultAsync();
 
             if (dbSupplier != null)
             {
@@ -53,7 +55,9 @@
 
         public async Task<string> EditAsync(string name, string country, string address, IFormFile newImage, string id)
         {
-            var supplier = this.suppliersRepository.All().FirstOrDefault(s => s.Id == id);
+            var supplier = await this.suppliersRepository
+                .All()
+                .FirstOrDefaultAsync(s => s.Id == id);
 
             if (supplier == null)
             {
@@ -78,7 +82,9 @@
 
         public async Task<string> DeleteAsync(string id)
         {
-            var supplier = this.suppliersRepository.All().Where(s => s.Id == id).FirstOrDefault();
+            var supplier = await this.suppliersRepository
+                .All()
+                .FirstOrDefaultAsync(s => s.Id == id);
 
             if (supplier == null)
             {
@@ -125,20 +131,18 @@
              return await this.suppliersRepository.All().CountAsync();
         }
 
-        public T GetById<T>(string id)
-        {
-            var supplier = this.suppliersRepository.All().Where(x => x.Id == id)
-                .To<T>().FirstOrDefault();
+        public async Task<T> GetById<T>(string id)
+        => await this.suppliersRepository
+                .All()
+                .Where(x => x.Id == id)
+                .To<T>()
+                .FirstOrDefaultAsync();
 
-            return supplier;
-        }
-
-        public T GetByName<T>(string name)
-        {
-            var supplier = this.suppliersRepository.All().Where(x => x.Name == name)
-                .To<T>().FirstOrDefault();
-
-            return supplier;
-        }
+        public async Task<T> GetByName<T>(string name)
+        => await this.suppliersRepository
+                .All()
+                .Where(x => x.Name == name)
+                .To<T>()
+                .FirstOrDefaultAsync();
     }
 }

--- a/Web/Lekarna.Web/Areas/Administration/Views/Suppliers/Create.cshtml
+++ b/Web/Lekarna.Web/Areas/Administration/Views/Suppliers/Create.cshtml
@@ -1,6 +1,8 @@
-﻿@model Lekarna.Web.ViewModels.Suppliers.SupplierCreateViewModel
+﻿@using static Lekarna.Common.GlobalConstants.Notifications
+@model Lekarna.Web.ViewModels.Suppliers.SupplierCreateViewModel
 @{
     this.ViewData["Title"] = "Create new supplier";
+    var error = this.TempData[Error];
 }
 
 <h1>@this.ViewData["Title"]</h1>
@@ -20,6 +22,10 @@
                     <label asp-for="Name">Name</label>
                     <input asp-for="Name" type="text" class="form-control" id="supplierName" placeholder="Enter supplier">
                     <span asp-validation-for="Name" class="text-danger"></span>
+                    @if (error != null)
+                    {
+                        <span class="text-danger">@error</span>
+                    }
                 </div>
                 <div class="form-group">
                     <label asp-for="Country">Country</label>


### PR DESCRIPTION
Replace redirection to error page with rendering of the same page with listing the error when the user tries to create supplier with already existed in database name (Administration/SuppliersController). Remove unnecessary code and usings. Make all the methods in SuppliersService async.